### PR TITLE
安全与问题更新，

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.11-slim
+
+# 更换为国内源以加快构建速度 (Debian 12 / Bookworm)
+RUN sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list.d/debian.sources
+
+# 安装 GCC (用于 C 语言) 和 OpenJDK (用于 Java)
+RUN apt-get update && apt-get install -y \
+    gcc \
+    default-jdk \
+    && rm -rf /var/lib/apt/lists/*
+
+# 复制插件的核心执行脚本到镜像中
+COPY exec/main.py /main.py
+
+# 设置工作目录
+WORKDIR /

--- a/exec.py
+++ b/exec.py
@@ -1,5 +1,6 @@
 import base64
 import asyncio
+import re
 
 from astrbot.api import logger
 
@@ -32,9 +33,36 @@ Github: https://github.com/TuF3i/AstrBot_Codex
 2.程序会从第一个\n处开始分割代码，所以在/code <language>后一定要先回车再输命令
 3.目前支持：Shell, Python, Java, C 四种语言
 '''
+
+    def _check_risk(self, code):
+        # 简单的关键词黑名单，防止明显的恶意破坏
+        # 注意：这不能替代沙箱隔离，只是第一道防线
+        risk_patterns = [
+            r":\(\)\s*\{\s*:\|:\s*&?\s*\}\s*;",  # Fork bomb
+            r"rm\s+(-rf|-r|-f)\s+/*",            # rm -rf / (dangerous looking)
+            r"mkfs",                              # Format disk
+            r"dd\s+if=/dev/zero",                 # Disk fill
+            r">\s*/dev/sd[a-z]",                  # Write to raw device
+            r"chmod\s+(-R)?\s+777\s+/",           # Permission destruction
+            r"wget|curl|nc|ping|ssh",             # Network tools (network is disabled anyway)
+        ]
+        
+        for pattern in risk_patterns:
+            if re.search(pattern, code, re.IGNORECASE):
+                return True, f"检测到潜在的高风险命令 (匹配规则: {pattern})"
+        return False, ""
     
     async def _execute_code(self, language, cmd_raw):
-        cmd = cmd_raw.split("\n", 1)[1]
+        parts = cmd_raw.split("\n", 1)
+        if len(parts) < 2:
+            return "格式错误：请在语言名称后换行输入代码。"
+        cmd = parts[1]
+
+        # 风险检查
+        is_risky, risk_msg = self._check_risk(cmd)
+        if is_risky:
+            return f"执行被拒绝: {risk_msg}"
+
         encoded_script = base64.b64encode(cmd.encode('utf-8')).decode('utf-8')
         logger.info(f"cmd:{cmd}")
         
@@ -43,7 +71,14 @@ Github: https://github.com/TuF3i/AstrBot_Codex
             container = await self.client.containers.create({
                 'Image': self.image_name,
                 'Cmd': ['python3', '/main.py', language, encoded_script],
-                'NetworkDisabled': False
+                'NetworkDisabled': True, # 禁用网络
+                'HostConfig': {
+                    'Memory': 128 * 1024 * 1024,  # 限制内存 128MB
+                    'NanoCpus': 500000000,        # 限制 CPU 0.5 核
+                    'PidsLimit': 64,              # 限制进程数防止 Fork 炸弹
+                    'CapDrop': ['ALL'],           # 移除所有 Linux Capabilities
+                    'Privileged': False           # 确保非特权模式
+                }
             })
             
             await container.start()     # 启动容器
@@ -59,11 +94,21 @@ Github: https://github.com/TuF3i/AstrBot_Codex
             # 获取容器日志
             logs = await container.log(stdout=True, stderr=True)
             log_line = ''.join(logs)
-            #log_line = logs[0]
             
+            # 限制输出长度，防止刷屏
+            if len(log_line) > 5000:
+                log_line = log_line[:5000] + "\n... (输出过长，已截断)"
+
             await container.delete(force=True)  # 删除容器
 
-            return base64.b64decode(log_line)
+            # 尝试清理日志输出中的空白字符
+            log_line = log_line.strip()
+            
+            try:
+                return base64.b64decode(log_line)
+            except Exception as decode_error:
+                logger.error(f"Base64 decode error. Raw output: {log_line}")
+                return f"执行结果解码失败: {decode_error}. 原始输出: {log_line}"
 
         except Exception as e:
             logger.info(f"执行代码时发生错误: {e}")


### PR DESCRIPTION
以下使用Gemini 3pro 完成更改，          
 在本地完成测试。需要作者进行复查与验证

@TuF3i 
🛡️ AstrBot Codex 插件安全更新日志
更新时间: 2025-12-24
文件: exec.py
版本: Security Hardened v1.1

1. 🚨 安全加固 (Security Hardening)
网络隔离:
设置 NetworkDisabled: True，彻底切断容器与互联网及局域网的连接，防止恶意下载、内网扫描及反向连接攻击。
资源限制 (Anti-DoS):
内存限制: 限制为 128MB (Memory: 128 * 1024 * 1024)，防止内存耗尽攻击。
CPU 限制: 限制为 0.5 核 (NanoCpus: 500000000)，防止死循环占用过多算力。
进程限制: 限制最大进程数为 64 (PidsLimit: 64)，有效防御 Fork 炸弹攻击。
权限最小化:
移除所有 Linux Capabilities (CapDrop: ['ALL'])。
强制非特权模式 (Privileged: False)，极大降低容器逃逸风险。
静态风险检测:
新增 _check_risk 方法，在执行前扫描代码中的高危关键词（如 rm -rf, mkfs, :(){ :|:& };: 等），直接拦截明显的恶意破坏行为。
2. ⚙️ 稳定性与健壮性 (Stability & Robustness)
输入格式校验:
修复了用户未换行输入代码导致插件报错崩溃的问题。现在会返回友好的“格式错误”提示。
输出防刷屏:
新增输出长度限制，超过 5000 字符的输出将被自动截断，防止恶意刷屏或日志爆炸。
解码容错处理:
优化了 Base64 解码逻辑。在解码失败（如容器输出报错信息而非 Base64）时，不再抛出 Incorrect padding 异常，而是直接返回原始的错误日志，便于排查环境问题（如 exec format error 或 ModuleNotFoundError）。
增加了 .strip() 操作，自动清理输出结果首尾的空白字符，减少因格式问题导致的解码失败.
 🛠️ 新增 Dockerfile (架构修复)
文件: Dockerfile
原因: 插件原版镜像 (tuf3i/code_exec) 是 ARM64 架构，而您的服务器是 x86_64 (AMD64) 架构，导致出现 exec format error 报错。
内容:
基于 python:3.11-slim 构建。
配置了国内软件源 (USTC) 以加速构建。
安装了 gcc (支持 C 语言) 和 default-jdk (支持 Java)。
将插件核心逻辑 main.py 植入镜像。
2. 🐳 重建并替换 Docker 镜像
操作: 使用上述 Dockerfile 在您的服务器上本地重新构建了 tuf3i/code_exec 镜像。
结果: 替换了不兼容的原版镜像，使 Python、C、Java 代码能够在您的服务器上正确运行。